### PR TITLE
Adding Lerobot dataset standard for teleoperated data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ version = "0.1.0"
 dependencies = [
  "dora-node-api",
  "eyre",
- "rustypot",
+ "rustypot 0.4.2",
  "serialport",
 ]
 
@@ -66,7 +66,8 @@ dependencies = [
  "clap",
  "dora-node-api",
  "eyre",
- "rustypot",
+ "lazy_static",
+ "rustypot 0.4.2",
  "serialport",
 ]
 
@@ -611,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "dora-arrow-convert"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65aadca952c9f1df1c9b95a87bf74b63add54eaa582d8cc4c8fd6ab37604175"
+checksum = "240774f0044a2919dd6a3dc96669f04cbccf21317b6f44dbe02ab044442f33f9"
 dependencies = [
  "arrow",
  "eyre",
@@ -621,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b5e0a3e9a96cd5772a706dcf11b7d6f1e3eb8c037d369ca39f2b2786c42fb3"
+checksum = "503227d2be74b6e17f834d71f0f26eb8800f367a6b2f7f35fed7b86f104596a1"
 dependencies = [
  "aligned-vec",
  "dora-message",
@@ -640,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6969f8e74cec74c7d1bc0aa2ac4b38554aead2cc49631c87ff9565f97b9204b"
+checksum = "ca4f69a3cd20470cea9413b423f311b82d40f226cc9680c1c4e6acb3745a106d"
 dependencies = [
  "arrow-data",
  "arrow-schema",
@@ -653,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee946ff6c1ec9928e854273246899026b43a87d2b904d576a9821509346ccaca"
+checksum = "7bfeefc63c1b7e7f0534b5dada9d7dcba4c640346dc6f71e902070b48060cc8d"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -676,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fdc8ba09c8396ef737cd4da0d4ada1f06bbe76656944f6c701e7b06c8b29340"
+checksum = "c1e21d2f86c81d8d44aad862b45075443768af2d69ced0d78ab3f9ca5c9211ed"
 dependencies = [
  "eyre",
  "opentelemetry",
@@ -1070,7 +1071,7 @@ version = "0.1.0"
 dependencies = [
  "dora-node-api",
  "eyre",
- "rustypot",
+ "rustypot 0.4.2 (git+https://github.com/haixuanTao/rustypot)",
  "serialport",
 ]
 
@@ -1081,7 +1082,7 @@ dependencies = [
  "clap",
  "dora-node-api",
  "eyre",
- "rustypot",
+ "rustypot 0.4.2 (git+https://github.com/haixuanTao/rustypot)",
  "serialport",
 ]
 
@@ -1740,6 +1741,16 @@ dependencies = [
 [[package]]
 name = "rustypot"
 version = "0.4.2"
+dependencies = [
+ "clap",
+ "log",
+ "paste",
+ "serialport",
+]
+
+[[package]]
+name = "rustypot"
+version = "0.4.2"
 source = "git+https://github.com/haixuanTao/rustypot#50ac05fb9298400c545d2b892b901e1a3930d339"
 dependencies = [
  "clap",
@@ -1862,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "shared-memory-server"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9105ab5690bc856ba3492b8c827d550bb8853867add16ac18d7fcd09342afb40"
+checksum = "3866006f4db55d1c1b93bfddb2be1f77eb14b6bbc3fd3d1ce5495e02a57791dd"
 dependencies = [
  "bincode",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ version = "0.1.0"
 dependencies = [
  "dora-node-api",
  "eyre",
- "rustypot 0.4.2",
+ "rustypot 0.4.2 (git+https://github.com/haixuanTao/rustypot?branch=angular-conversion)",
  "serialport",
 ]
 
@@ -67,7 +67,7 @@ dependencies = [
  "dora-node-api",
  "eyre",
  "lazy_static",
- "rustypot 0.4.2",
+ "rustypot 0.4.2 (git+https://github.com/haixuanTao/rustypot?branch=angular-conversion)",
  "serialport",
 ]
 
@@ -1741,6 +1741,7 @@ dependencies = [
 [[package]]
 name = "rustypot"
 version = "0.4.2"
+source = "git+https://github.com/haixuanTao/rustypot?branch=angular-conversion#d35010e73b35decae69efb2f796d31be5b518b11"
 dependencies = [
  "clap",
  "log",

--- a/aloha/graphs/eval.yml
+++ b/aloha/graphs/eval.yml
@@ -9,18 +9,6 @@ nodes:
       outputs:
         - puppet_position
 
-  # - id: aloha-client
-  # custom:
-  # source: cargo
-  # args: run --release -p aloha-teleop
-  # inputs:
-  # heartbeat: dora/timer/millis/20
-  # outputs:
-  # - puppet_goal_position
-  # - puppet_position
-  # - puppet_velocity
-  # - puppet_current
-
   - id: plot
     custom:
       source: ../nodes/plot_node.py

--- a/aloha/graphs/eval.yml
+++ b/aloha/graphs/eval.yml
@@ -1,0 +1,153 @@
+nodes:
+  - id: aloha-client
+    custom:
+      source: cargo
+      args: run --release -p aloha-client
+      inputs:
+        puppet_goal_position: eval/action
+        tick: dora/timer/millis/5
+      outputs:
+        - puppet_position
+
+  # - id: aloha-client
+  # custom:
+  # source: cargo
+  # args: run --release -p aloha-teleop
+  # inputs:
+  # heartbeat: dora/timer/millis/20
+  # outputs:
+  # - puppet_goal_position
+  # - puppet_position
+  # - puppet_velocity
+  # - puppet_current
+
+  - id: plot
+    custom:
+      source: ../nodes/plot_node.py
+      inputs:
+        image: cam_right_wrist/image
+        action: eval/action
+        puppet_position: aloha-client/puppet_position
+      envs:
+        IMAGE_WIDTH: 640
+        IMAGE_HEIGHT: 480
+
+  - id: cam_left_wrist
+    custom:
+      source: ../nodes/webcam.py
+      inputs:
+        tick: dora/timer/millis/33
+      outputs:
+        - image
+      envs:
+        CAMERA_ID: 2
+
+  - id: cam_right_wrist
+    custom:
+      source: ../nodes/webcam.py
+      inputs:
+        tick: dora/timer/millis/33
+      outputs:
+        - image
+      envs:
+        CAMERA_ID: 22
+
+  - id: cam_low
+    custom:
+      source: ../nodes/webcam.py
+      inputs:
+        tick: dora/timer/millis/33
+      outputs:
+        - image
+      envs:
+        CAMERA_ID: 14
+
+  - id: cam_high
+    custom:
+      source: ../nodes/webcam.py
+      inputs:
+        tick: dora/timer/millis/33
+      outputs:
+        - image
+      envs:
+        CAMERA_ID: 8
+
+  - id: eval
+    custom:
+      source: python
+      args: /home/rcadene/lerobot/lerobot/scripts/eval.py -p cadene/aloha_act_no_state_aloha_v2_static_dora_test_wrist_gripper eval.n_episodes=1 eval.batch_size=1 env.episode_length=20000
+      inputs:
+        agent_pos: aloha-client/puppet_position
+        cam_left_wrist: cam_left_wrist/image
+        cam_right_wrist: cam_right_wrist/image
+        cam_low: cam_low/image
+        cam_high: cam_high/image
+      outputs:
+        - action
+
+  - id: keyboard
+    custom:
+      source: ../nodes/keyboard_node.py
+      inputs:
+        heartbeat: dora/timer/millis/20
+      outputs:
+        - space
+        - failed
+
+  - id: cam_saver_left_wrist
+    custom:
+      source: ../nodes/lerobot_webcam_saver.py
+      inputs:
+        image: cam_left_wrist/image
+        record_episode: keyboard/space
+      outputs:
+        - saved_image
+      envs:
+        CAMERA_NAME: observation.images.cam_left_wrist
+
+  - id: cam_saver_right_wrist
+    custom:
+      source: ../nodes/lerobot_webcam_saver.py
+      inputs:
+        image: cam_right_wrist/image
+        record_episode: keyboard/space
+      outputs:
+        - saved_image
+      envs:
+        CAMERA_NAME: observation.images.cam_right_wrist
+
+  - id: cam_saver_low
+    custom:
+      source: ../nodes/lerobot_webcam_saver.py
+      inputs:
+        image: cam_low/image
+        record_episode: keyboard/space
+      outputs:
+        - saved_image
+      envs:
+        CAMERA_NAME: observation.images.cam_low
+
+  - id: cam_saver_high
+    custom:
+      source: ../nodes/lerobot_webcam_saver.py
+      inputs:
+        image: cam_high/image
+        record_episode: keyboard/space
+      outputs:
+        - saved_image
+      envs:
+        CAMERA_NAME: observation.images.cam_high
+
+  - id: dora-record
+    custom:
+      build: cargo install --git https://github.com/dora-rs/dora dora-record
+      source: dora-record
+      inputs:
+        action: eval/action
+        observation.state: aloha-client/puppet_position
+        episode_index: keyboard/space
+        failed_episode_index: keyboard/failed
+        observation.images.cam_left_wrist: cam_saver_left_wrist/saved_image
+        observation.images.cam_right_wrist: cam_saver_right_wrist/saved_image
+        observation.images.cam_low: cam_saver_low/saved_image
+        observation.images.cam_high: cam_saver_high/saved_image

--- a/aloha/graphs/gym.yml
+++ b/aloha/graphs/gym.yml
@@ -1,0 +1,40 @@
+nodes:
+  - id: aloha-client
+    custom:
+      source: cargo
+      args: run -p aloha-client --release
+      inputs:
+        puppet_goal_position: dora-gym/action
+        tick: dora/timer/millis/33
+      outputs:
+        - puppet_position
+
+  - id: plot
+    custom:
+      source: ../nodes/plot_node.py
+      inputs:
+        image: cam_left_wrist/image
+      envs:
+        IMAGE_WIDTH: 640
+        IMAGE_HEIGHT: 480
+  
+  - id: cam_left_wrist
+    custom:
+      source: ../nodes/webcam.py
+      inputs:
+        tick: dora/timer/millis/33
+      outputs:
+        - image
+      envs:
+        CAMERA_ID: 2
+
+  - id: dora-gym
+    custom:
+      source: ../nodes/gym_dora_node.py
+      inputs:
+        # puppet_left_goal_position: teleop_left/puppet_goal_position
+        # puppet_left_state: teleop_left/puppet_state
+        agent_pos: aloha-client/puppet_position
+        cam_left_wrist: cam_left_wrist/image
+      outputs:
+        - action

--- a/aloha/graphs/gym.yml
+++ b/aloha/graphs/gym.yml
@@ -17,7 +17,7 @@ nodes:
       envs:
         IMAGE_WIDTH: 640
         IMAGE_HEIGHT: 480
-  
+
   - id: cam_left_wrist
     custom:
       source: ../nodes/webcam.py
@@ -32,8 +32,6 @@ nodes:
     custom:
       source: ../nodes/gym_dora_node.py
       inputs:
-        # puppet_left_goal_position: teleop_left/puppet_goal_position
-        # puppet_left_state: teleop_left/puppet_state
         agent_pos: aloha-client/puppet_position
         cam_left_wrist: cam_left_wrist/image
       outputs:

--- a/aloha/graphs/record_2arms_teleop.yml
+++ b/aloha/graphs/record_2arms_teleop.yml
@@ -33,7 +33,7 @@ nodes:
         episode_index: keyboard/space
         observation.images.cam_left_wrist: cam_saver_left_wrist/saved_image
         observation.images.cam_right_wrist: cam_saver_right_wrist/saved_image
-        observation.images.cam_bottom: cam_saver_bottom/saved_image
+        observation.images.cam_low: cam_saver_low/saved_image
         observation.images.cam_high: cam_saver_high/saved_image
 
   - id: cam_left_wrist
@@ -56,7 +56,7 @@ nodes:
       envs:
         CAMERA_ID: 22
   
-  - id: cam_bottom
+  - id: cam_low
     custom:
       source: ../nodes/webcam.py
       inputs:
@@ -106,16 +106,16 @@ nodes:
       envs:
         CAMERA_NAME: cam_right_wrist
 
-  - id: cam_saver_bottom
+  - id: cam_saver_low
     custom:
       source: ../nodes/lerobot_webcam_saver.py
       inputs:
-        image: cam_bottom/image
+        image: cam_low/image
         record_episode: keyboard/space
       outputs:
         - saved_image
       envs:
-        CAMERA_NAME: cam_bottom
+        CAMERA_NAME: cam_low
 
   - id: cam_saver_high
     custom:
@@ -149,7 +149,7 @@ nodes:
       # envs:
         # CAMERA_ID: 128422270109
   
-  # - id: cam_bottom
+  # - id: cam_low
     # custom:
       # source: ../nodes/realsense_node.py
       # inputs:

--- a/aloha/graphs/record_2arms_teleop.yml
+++ b/aloha/graphs/record_2arms_teleop.yml
@@ -1,16 +1,10 @@
 nodes:
-  # - id: teleop_left
-    # custom:
-      # source: cargo
-      # args: run --release -p aloha-teleop  -- --master-path /dev/ttyDXL_master_left --puppet-path /dev/ttyDXL_puppet_left
-      # outputs:
-        # - puppet_goal_position
-        # - puppet_state
+
   
   - id: teleop_right
     custom:
       source: cargo
-      args: run --release -p aloha-teleop  -- --master-path /dev/ttyDXL_master_right --puppet-path /dev/ttyDXL_puppet_right
+      args: run --release -p aloha-teleop  
       inputs:
         heartbeat: dora/timer/millis/20
       outputs:
@@ -24,13 +18,12 @@ nodes:
       build: cargo install --git https://github.com/dora-rs/dora dora-record
       source: dora-record
       inputs:
-        # puppet_left_goal_position: teleop_left/puppet_goal_position
         action: teleop_right/puppet_goal_position
-        # puppet_left_state: teleop_left/puppet_state
         observation.state: teleop_right/puppet_position
         observation.velocity: teleop_right/puppet_velocity
         observation.effort: teleop_right/puppet_current
         episode_index: keyboard/space
+        failed_episode_index: keyboard/failed
         observation.images.cam_left_wrist: cam_saver_left_wrist/saved_image
         observation.images.cam_right_wrist: cam_saver_right_wrist/saved_image
         observation.images.cam_low: cam_saver_low/saved_image
@@ -83,6 +76,7 @@ nodes:
         heartbeat: dora/timer/millis/20
       outputs:
         - space
+        - failed
 
   - id: cam_saver_left_wrist
     custom:
@@ -93,7 +87,7 @@ nodes:
       outputs:
         - saved_image
       envs:
-        CAMERA_NAME: cam_left_wrist
+        CAMERA_NAME: observation.images.cam_left_wrist
 
   - id: cam_saver_right_wrist
     custom:
@@ -104,7 +98,7 @@ nodes:
       outputs:
         - saved_image
       envs:
-        CAMERA_NAME: cam_right_wrist
+        CAMERA_NAME: observation.images.cam_right_wrist
 
   - id: cam_saver_low
     custom:
@@ -115,7 +109,7 @@ nodes:
       outputs:
         - saved_image
       envs:
-        CAMERA_NAME: cam_low
+        CAMERA_NAME: observation.images.cam_low
 
   - id: cam_saver_high
     custom:
@@ -126,7 +120,7 @@ nodes:
       outputs:
         - saved_image
       envs:
-        CAMERA_NAME: cam_high
+        CAMERA_NAME: observation.images.cam_high
 
   # Realsense seems to require specific power that makes it unreliable in our current setup
   # - id: cam_left_wrist

--- a/aloha/graphs/record_2arms_teleop.yml
+++ b/aloha/graphs/record_2arms_teleop.yml
@@ -1,10 +1,8 @@
 nodes:
-
-  
   - id: teleop_right
     custom:
       source: cargo
-      args: run --release -p aloha-teleop  
+      args: run --release -p aloha-teleop
       inputs:
         heartbeat: dora/timer/millis/20
       outputs:
@@ -48,7 +46,7 @@ nodes:
         - image
       envs:
         CAMERA_ID: 22
-  
+
   - id: cam_low
     custom:
       source: ../nodes/webcam.py
@@ -58,7 +56,7 @@ nodes:
         - image
       envs:
         CAMERA_ID: 14
-  
+
   - id: cam_high
     custom:
       source: ../nodes/webcam.py
@@ -68,9 +66,9 @@ nodes:
         - image
       envs:
         CAMERA_ID: 8
-  
+
   - id: keyboard
-    custom: 
+    custom:
       source: ../nodes/keyboard_node.py
       inputs:
         heartbeat: dora/timer/millis/20
@@ -124,42 +122,41 @@ nodes:
 
   # Realsense seems to require specific power that makes it unreliable in our current setup
   # - id: cam_left_wrist
-    # custom:
-      # source: ../nodes/realsense_node.py
-      # inputs:
-        # tick: dora/timer/millis/2
-      # outputs:
-        # - image
-      # envs:
-        # CAMERA_ID: 128422271614
+  # custom:
+  # source: ../nodes/realsense_node.py
+  # inputs:
+  # tick: dora/timer/millis/2
+  # outputs:
+  # - image
+  # envs:
+  # CAMERA_ID: 128422271614
 
   # - id: cam_right_wrist
-    # custom:
-      # source: ../nodes/realsense_node.py
-      # inputs:
-        # tick: dora/timer/millis/2
-      # outputs:
-        # - image
-      # envs:
-        # CAMERA_ID: 128422270109
-  
+  # custom:
+  # source: ../nodes/realsense_node.py
+  # inputs:
+  # tick: dora/timer/millis/2
+  # outputs:
+  # - image
+  # envs:
+  # CAMERA_ID: 128422270109
+
   # - id: cam_low
-    # custom:
-      # source: ../nodes/realsense_node.py
-      # inputs:
-        # tick: dora/timer/millis/2
-      # outputs:
-        # - image
-      # envs:
-        # CAMERA_ID: 128422271393
-  
+  # custom:
+  # source: ../nodes/realsense_node.py
+  # inputs:
+  # tick: dora/timer/millis/2
+  # outputs:
+  # - image
+  # envs:
+  # CAMERA_ID: 128422271393
+
   # - id: cam_high
-    # custom:
-      # source: ../nodes/realsense_node.py
-      # inputs:
-        # tick: dora/timer/millis/2
-      # outputs:
-        # - image
-      # envs:
-        # CAMERA_ID: 128422271609
-  
+  # custom:
+  # source: ../nodes/realsense_node.py
+  # inputs:
+  # tick: dora/timer/millis/2
+  # outputs:
+  # - image
+  # envs:
+  # CAMERA_ID: 128422271609

--- a/aloha/graphs/record_2arms_teleop.yml
+++ b/aloha/graphs/record_2arms_teleop.yml
@@ -17,7 +17,7 @@ nodes:
         - puppet_goal_position
         - puppet_position
         - puppet_velocity
-        - puppet_load
+        - puppet_current
 
   - id: dora-record
     custom:
@@ -29,7 +29,7 @@ nodes:
         # puppet_left_state: teleop_left/puppet_state
         observation.state: teleop_right/puppet_position
         observation.velocity: teleop_right/puppet_velocity
-        observation.effort: teleop_right/puppet_load
+        observation.effort: teleop_right/puppet_current
         episode_index: keyboard/space
         observation.images.cam_left_wrist: cam_saver_left_wrist/saved_image
         observation.images.cam_right_wrist: cam_saver_right_wrist/saved_image
@@ -44,7 +44,7 @@ nodes:
       outputs:
         - image
       envs:
-        CAMERA_ID: 22
+        CAMERA_ID: 2
 
   - id: cam_right_wrist
     custom:
@@ -54,7 +54,7 @@ nodes:
       outputs:
         - image
       envs:
-        CAMERA_ID: 14
+        CAMERA_ID: 22
   
   - id: cam_bottom
     custom:
@@ -64,7 +64,7 @@ nodes:
       outputs:
         - image
       envs:
-        CAMERA_ID: 8
+        CAMERA_ID: 14
   
   - id: cam_high
     custom:
@@ -74,7 +74,7 @@ nodes:
       outputs:
         - image
       envs:
-        CAMERA_ID: 2
+        CAMERA_ID: 8
   
   - id: keyboard
     custom: 

--- a/aloha/graphs/record_2arms_teleop.yml
+++ b/aloha/graphs/record_2arms_teleop.yml
@@ -15,7 +15,9 @@ nodes:
         heartbeat: dora/timer/millis/20
       outputs:
         - puppet_goal_position
-        - puppet_state
+        - puppet_position
+        - puppet_velocity
+        - puppet_load
 
   - id: dora-record
     custom:
@@ -25,12 +27,14 @@ nodes:
         # puppet_left_goal_position: teleop_left/puppet_goal_position
         action: teleop_right/puppet_goal_position
         # puppet_left_state: teleop_left/puppet_state
-        state: teleop_right/puppet_state
+        observation.state: teleop_right/puppet_position
+        observation.velocity: teleop_right/puppet_velocity
+        observation.effort: teleop_right/puppet_load
         episode_index: keyboard/space
-        cam_left_wrist: cam_saver_left_wrist/saved_image
-        cam_right_wrist: cam_saver_right_wrist/saved_image
-        cam_bottom: cam_saver_bottom/saved_image
-        cam_high_leader: cam_saver_high/saved_image
+        observation.images.cam_left_wrist: cam_saver_left_wrist/saved_image
+        observation.images.cam_right_wrist: cam_saver_right_wrist/saved_image
+        observation.images.cam_bottom: cam_saver_bottom/saved_image
+        observation.images.cam_high: cam_saver_high/saved_image
 
   - id: cam_left_wrist
     custom:

--- a/aloha/nodes/aloha-client/Cargo.toml
+++ b/aloha/nodes/aloha-client/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2021"
 [dependencies]
 
 serialport = "4.2.0"
-rustypot = { path = "/home/rcadene/rustypot" } # git = "https://github.com/haixuanTao/rustypot" }
+rustypot = { git = "https://github.com/haixuanTao/rustypot", branch = "angular-conversion" }
 eyre = "0.6.12"
 dora-node-api = "0.3.4"

--- a/aloha/nodes/aloha-client/Cargo.toml
+++ b/aloha/nodes/aloha-client/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2021"
 [dependencies]
 
 serialport = "4.2.0"
-rustypot = { git = "https://github.com/haixuanTao/rustypot" }
+rustypot = { path = "/home/rcadene/rustypot" } # git = "https://github.com/haixuanTao/rustypot" }
 eyre = "0.6.12"
-dora-node-api = "0.3.3"
+dora-node-api = "0.3.4"

--- a/aloha/nodes/aloha-client/src/main.rs
+++ b/aloha/nodes/aloha-client/src/main.rs
@@ -95,6 +95,11 @@ fn main() -> Result<()> {
                 )
                 .expect("Communication error");
                 pos_left.extend_from_slice(&pos_right);
+
+                let pos: Vec<f64> = pos_left
+                    .iter()
+                    .map(|&x| xm::conv::pos_to_radians(x))
+                    .collect();
                 node.send_output(
                     DataId::from("puppet_position".to_owned()),
                     Default::default(),

--- a/aloha/nodes/aloha-client/src/main.rs
+++ b/aloha/nodes/aloha-client/src/main.rs
@@ -30,6 +30,20 @@ fn main() -> Result<()> {
         &[1; 9],
     )
     .expect("Communication error");
+    xm::sync_write_operating_mode(
+        &io,
+        puppet_left_serial_port.as_mut(),
+        &[1, 2, 3, 4, 5, 6, 7, 8, 9],
+        &[5; 9],
+    )
+    .expect("Communication error");
+    xm::sync_write_operating_mode(
+        &io,
+        puppet_right_serial_port.as_mut(),
+        &[1, 2, 3, 4, 5, 6, 7, 8, 9],
+        &[5; 9],
+    )
+    .expect("Communication error");
 
     while let Some(Event::Input {
         id,

--- a/aloha/nodes/aloha-client/src/main.rs
+++ b/aloha/nodes/aloha-client/src/main.rs
@@ -30,19 +30,9 @@ fn main() -> Result<()> {
         &[1; 9],
     )
     .expect("Communication error");
-    xm::sync_write_operating_mode(
-        &io,
-        puppet_left_serial_port.as_mut(),
-        &[1, 2, 3, 4, 5, 6, 7, 8, 9],
-        &[5; 9],
-    )
+    xm::sync_write_operating_mode(&io, puppet_left_serial_port.as_mut(), &[9], &[5])
     .expect("Communication error");
-    xm::sync_write_operating_mode(
-        &io,
-        puppet_right_serial_port.as_mut(),
-        &[1, 2, 3, 4, 5, 6, 7, 8, 9],
-        &[5; 9],
-    )
+    xm::sync_write_operating_mode(&io, puppet_right_serial_port.as_mut(), &[9], &[5])
     .expect("Communication error");
 
     while let Some(Event::Input {
@@ -103,7 +93,7 @@ fn main() -> Result<()> {
                 node.send_output(
                     DataId::from("puppet_position".to_owned()),
                     Default::default(),
-                    pos_left.into_arrow(),
+                    pos.into_arrow(),
                 )?;
             }
             _ => todo!(),

--- a/aloha/nodes/aloha-teleop/Cargo.toml
+++ b/aloha/nodes/aloha-teleop/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2021"
 [dependencies]
 
 serialport = "4.2.0"
-rustypot = { git = "https://github.com/haixuanTao/rustypot" }
+rustypot = { path = "/home/rcadene/rustypot" }      # git = "https://github.com/haixuanTao/rustypot" }
 eyre = "0.6.12"
 clap = { version = "4.5.4", features = ["derive"] }
-dora-node-api = "0.3.3"
+dora-node-api = "0.3.4"
+lazy_static = "1.4.0"

--- a/aloha/nodes/aloha-teleop/Cargo.toml
+++ b/aloha/nodes/aloha-teleop/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 
 serialport = "4.2.0"
-rustypot = { path = "/home/rcadene/rustypot" }      # git = "https://github.com/haixuanTao/rustypot" }
+rustypot = { git = "https://github.com/haixuanTao/rustypot", branch = "angular-conversion" }
 eyre = "0.6.12"
 clap = { version = "4.5.4", features = ["derive"] }
 dora-node-api = "0.3.4"

--- a/aloha/nodes/aloha-teleop/src/main.rs
+++ b/aloha/nodes/aloha-teleop/src/main.rs
@@ -132,6 +132,13 @@ fn main() -> Result<()> {
             &[1; 9],
         )
         .expect("Communication error");
+        xm::sync_write_operating_mode(
+            &io,
+            puppet_right_serial_port.as_mut(),
+            &[1, 2, 3, 4, 5, 6, 7, 8, 9],
+            &[5; 9],
+        )
+        .expect("Communication error");
         Some(main_multithreaded(
             io,
             master_right_serial_port,
@@ -160,6 +167,16 @@ fn main() -> Result<()> {
         &[1; 9],
     )
     .expect("Communication error");
+
+    // Set operating mode to current based position control
+    xm::sync_write_operating_mode(
+        &io,
+        puppet_left_serial_port.as_mut(),
+        &[1, 2, 3, 4, 5, 6, 7, 8, 9],
+        &[5; 9],
+    )
+    .expect("Communication error");
+
     let join_left = main_multithreaded(
         io,
         master_left_serial_port,

--- a/aloha/nodes/aloha-teleop/src/main.rs
+++ b/aloha/nodes/aloha-teleop/src/main.rs
@@ -34,7 +34,7 @@ struct Args {
 enum State {
     Position(Vec<f64>),
     Velocity(Vec<f64>),
-    Load(Vec<u16>),
+    Current(Vec<u16>),
     GoalPosition(Vec<f64>),
 }
 
@@ -74,7 +74,7 @@ fn main_multithreaded(
             &[1, 2, 3, 4, 5, 6, 7, 8, 9],
         )
         .expect("Read Communication error");
-        tx_dora_read.send(State::Load(load)).unwrap();
+        tx_dora_read.send(State::Current(load)).unwrap();
     });
 
     let io = DynamixelSerialIO::v2();
@@ -115,8 +115,8 @@ fn main_multithreaded(
                     let output = DataId::from("puppet_velocity".to_owned());
                     node.send_output(output.clone(), parameters, vel.into_arrow())?;
                 }
-                State::Load(load) => {
-                    let output = DataId::from("puppet_load".to_owned());
+                State::Current(load) => {
+                    let output = DataId::from("puppet_current".to_owned());
                     node.send_output(output.clone(), parameters, load.into_arrow())?;
                 }
                 State::GoalPosition(pos) => {

--- a/aloha/nodes/aloha-teleop/src/main.rs
+++ b/aloha/nodes/aloha-teleop/src/main.rs
@@ -4,6 +4,7 @@ use rustypot::{device::xm, DynamixelSerialIO};
 use serialport::SerialPort;
 use std::{
     sync::mpsc,
+    thread::JoinHandle,
     time::{Duration, Instant},
 };
 const MAX_MASTER_GRIPER: f64 = 0.7761942786701344;
@@ -18,17 +19,17 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
+    #[arg(short, long, default_value = "/dev/ttyDXL_master_left")]
+    master_left_path: String,
+
+    #[arg(short, long, default_value = "/dev/ttyDXL_puppet_left")]
+    puppet_left_path: String,
+
     #[arg(short, long, default_value = "/dev/ttyDXL_master_right")]
-    master_path: String,
+    master_right_path: Option<String>,
 
     #[arg(short, long, default_value = "/dev/ttyDXL_puppet_right")]
-    puppet_path: String,
-
-    #[arg(long, default_value = "1000000")]
-    master_baudrate: u32,
-
-    #[arg(long, default_value = "1000000")]
-    puppet_baudrate: u32,
+    puppet_right_path: Option<String>,
 }
 
 enum State {
@@ -37,14 +38,20 @@ enum State {
     Current(Vec<u16>),
     GoalPosition(Vec<f64>),
 }
+#[derive(Clone, Copy)]
+enum Side {
+    Left,
+    Right,
+}
 
 fn main_multithreaded(
     io: DynamixelSerialIO,
     mut master_serial_port: Box<dyn SerialPort>,
     mut puppet_serial_port: Box<dyn SerialPort>,
-) -> Result<()> {
+    side: Side,
+    tx_dora: mpsc::Sender<(Side, State)>,
+) -> Result<JoinHandle<()>> {
     let (tx, rx) = mpsc::channel();
-    let (tx_dora, rx_dora) = mpsc::channel();
     let tx_dora_read = tx_dora.clone();
     std::thread::spawn(move || loop {
         let now = Instant::now();
@@ -56,7 +63,7 @@ fn main_multithreaded(
         .expect("Read Communication error");
         let radians: Vec<f64> = pos.iter().map(|&x| xm::conv::pos_to_radians(x)).collect();
         tx.send((now, radians.clone())).unwrap();
-        tx_dora_read.send(State::Position(radians)).unwrap();
+        tx_dora.send((side, State::Position(radians))).unwrap();
         let vel = xm::sync_read_present_velocity(
             &io,
             master_serial_port.as_mut(),
@@ -67,11 +74,11 @@ fn main_multithreaded(
             .iter()
             .map(|&x| xm::conv::abs_speed_to_rad_per_sec(x))
             .collect();
-        tx_dora_read.send(State::Velocity(rad_per_sec)).unwrap();
+        tx_dora.send((side, State::Velocity(rad_per_sec))).unwrap();
         let load =
             xm::sync_read_present_current(&io, master_serial_port.as_mut(), &[1, 2, 4, 6, 7, 8, 9]) // 3 and 5 are skipped as thery share the same position as 2 and 4
                 .expect("Read Communication error");
-        tx_dora_read.send(State::Current(load)).unwrap();
+        tx_dora.send((side, State::Current(load))).unwrap();
     });
 
     let io = DynamixelSerialIO::v2();
@@ -80,7 +87,9 @@ fn main_multithreaded(
             pos[6] = (pos[6] - MIN_MASTER_GRIPER) * (MAX_PUPPET_GRIPER - MIN_PUPPET_GRIPER)
                 / (MAX_MASTER_GRIPER - MIN_MASTER_GRIPER)
                 + MIN_PUPPET_GRIPER;
-            tx_dora.send(State::GoalPosition(pos.clone())).unwrap();
+            tx_dora_read
+                .send((side, State::GoalPosition(pos.clone())))
+                .unwrap();
             pos.insert(2, pos[1]);
             pos.insert(4, pos[3]);
             let pos: Vec<u32> = pos.iter().map(|&x| xm::conv::radians_to_pos(x)).collect();
@@ -96,58 +105,130 @@ fn main_multithreaded(
         }
     });
 
-    if std::env::var("DORA_NODE_CONFIG").is_ok() {
-        let (mut node, mut events) = DoraNode::init_from_env()?;
-        while let Ok(target) = rx_dora.recv() {
-            let parameters = MetadataParameters::default();
-            match target {
-                State::Position(pos) => {
-                    let output = DataId::from("puppet_position".to_owned());
-                    node.send_output(output.clone(), parameters, pos.into_arrow())?;
-                }
-                State::Velocity(vel) => {
-                    let output = DataId::from("puppet_velocity".to_owned());
-                    node.send_output(output.clone(), parameters, vel.into_arrow())?;
-                }
-                State::Current(load) => {
-                    let output = DataId::from("puppet_current".to_owned());
-                    node.send_output(output.clone(), parameters, load.into_arrow())?;
-                }
-                State::GoalPosition(pos) => {
-                    let output = DataId::from("puppet_goal_position".to_owned());
-                    node.send_output(output.clone(), parameters, pos.into_arrow())?;
-                }
-            }
-            if events.recv_timeout(Duration::from_nanos(100)).is_none() {
-                println!("Events channel finished");
-                break;
-            }
-        }
-    } else {
-        join.join().unwrap();
-    };
-    Ok(())
+    Ok(join)
 }
 
 fn main() -> Result<()> {
     let args = Args::parse();
-    let master_serial_port = serialport::new(args.master_path, args.master_baudrate)
+    let (tx_dora, rx_dora) = mpsc::channel();
+    // right arm
+    let join_right = if let (Some(master_right_path), Some(puppet_right_path)) =
+        (args.master_right_path.clone(), args.puppet_right_path)
+    {
+        let master_right_serial_port = serialport::new(master_right_path, 1000000)
+            .timeout(Duration::from_millis(2))
+            .open()
+            .context("Failed to open port")?;
+        let mut puppet_right_serial_port = serialport::new(puppet_right_path, 1000000)
+            .timeout(Duration::from_millis(2))
+            .open()
+            .context("Failed to open port")?;
+
+        let io = DynamixelSerialIO::v2();
+        xm::sync_write_torque_enable(
+            &io,
+            puppet_right_serial_port.as_mut(),
+            &[1, 2, 3, 4, 5, 6, 7, 8, 9],
+            &[1; 9],
+        )
+        .expect("Communication error");
+        Some(main_multithreaded(
+            io,
+            master_right_serial_port,
+            puppet_right_serial_port,
+            Side::Right,
+            tx_dora.clone(),
+        )?)
+    } else {
+        None
+    };
+
+    // Left arm
+    let master_left_serial_port = serialport::new(args.master_left_path, 1000000)
         .timeout(Duration::from_millis(2))
         .open()
         .context("Failed to open port")?;
-    let mut puppet_serial_port = serialport::new(args.puppet_path, args.puppet_baudrate)
+    let mut puppet_left_serial_port = serialport::new(args.puppet_left_path, 1000000)
         .timeout(Duration::from_millis(2))
         .open()
         .context("Failed to open port")?;
     let io = DynamixelSerialIO::v2();
     xm::sync_write_torque_enable(
         &io,
-        puppet_serial_port.as_mut(),
+        puppet_left_serial_port.as_mut(),
         &[1, 2, 3, 4, 5, 6, 7, 8, 9],
         &[1; 9],
     )
     .expect("Communication error");
+    let join_left = main_multithreaded(
+        io,
+        master_left_serial_port,
+        puppet_left_serial_port,
+        Side::Left,
+        tx_dora,
+    )?;
 
-    main_multithreaded(io, master_serial_port, puppet_serial_port)?;
+    if std::env::var("DORA_NODE_CONFIG").is_ok() {
+        let (mut node, mut events) = DoraNode::init_from_env()?;
+        let mut pos_right = Vec::new();
+        let mut vel_right = Vec::new();
+        let mut current_right = Vec::new();
+        let mut goal_right = Vec::new();
+        while let Ok((side, target)) = rx_dora.recv() {
+            match side {
+                Side::Left => {
+                    let parameters = MetadataParameters::default();
+
+                    // Skip if we don't have any data from the right arm
+                    if args.master_right_path.is_some() && pos_right.is_empty() {
+                        continue;
+                    }
+                    match target {
+                        State::Position(mut pos) => {
+                            pos.extend_from_slice(&pos_right);
+                            let output = DataId::from("puppet_position".to_owned());
+                            node.send_output(output.clone(), parameters, pos.into_arrow())?;
+                        }
+                        State::Velocity(mut vel) => {
+                            vel.extend_from_slice(&vel_right);
+                            let output = DataId::from("puppet_velocity".to_owned());
+                            node.send_output(output.clone(), parameters, vel.into_arrow())?;
+                        }
+                        State::Current(mut load) => {
+                            load.extend_from_slice(&current_right);
+                            let output = DataId::from("puppet_current".to_owned());
+                            node.send_output(output.clone(), parameters, load.into_arrow())?;
+                        }
+                        State::GoalPosition(mut pos) => {
+                            pos.extend_from_slice(&goal_right);
+                            let output = DataId::from("puppet_goal_position".to_owned());
+                            node.send_output(output.clone(), parameters, pos.into_arrow())?;
+                        }
+                    }
+                    if events.recv_timeout(Duration::from_nanos(100)).is_none() {
+                        println!("Events channel finished");
+                        break;
+                    }
+                }
+                Side::Right => match target {
+                    State::Position(pos) => {
+                        pos_right = pos;
+                    }
+                    State::Velocity(vel) => {
+                        vel_right = vel;
+                    }
+                    State::Current(load) => {
+                        current_right = load;
+                    }
+                    State::GoalPosition(pos) => {
+                        goal_right = pos;
+                    }
+                },
+            }
+        }
+    } else {
+        join_left.join().unwrap();
+        join_right.map(|join| join.join().unwrap());
+    };
     Ok(())
 }

--- a/aloha/nodes/aloha-teleop/src/main.rs
+++ b/aloha/nodes/aloha-teleop/src/main.rs
@@ -132,13 +132,9 @@ fn main() -> Result<()> {
             &[1; 9],
         )
         .expect("Communication error");
-        xm::sync_write_operating_mode(
-            &io,
-            puppet_right_serial_port.as_mut(),
-            &[1, 2, 3, 4, 5, 6, 7, 8, 9],
-            &[5; 9],
-        )
-        .expect("Communication error");
+        // Set operating mode to current based position control to not overload the gripper
+        xm::sync_write_operating_mode(&io, puppet_right_serial_port.as_mut(), &[9], &[5])
+            .expect("Communication error");
         Some(main_multithreaded(
             io,
             master_right_serial_port,
@@ -168,14 +164,9 @@ fn main() -> Result<()> {
     )
     .expect("Communication error");
 
-    // Set operating mode to current based position control
-    xm::sync_write_operating_mode(
-        &io,
-        puppet_left_serial_port.as_mut(),
-        &[1, 2, 3, 4, 5, 6, 7, 8, 9],
-        &[5; 9],
-    )
-    .expect("Communication error");
+    // Set operating mode to current based position control to not overload the gripper
+    xm::sync_write_operating_mode(&io, puppet_left_serial_port.as_mut(), &[9], &[5])
+        .expect("Communication error");
 
     let join_left = main_multithreaded(
         io,

--- a/aloha/nodes/gym_dora_node.py
+++ b/aloha/nodes/gym_dora_node.py
@@ -1,0 +1,58 @@
+import gymnasium as gym
+
+import gym_dora  # noqa: F401
+import pandas as pd
+import time
+from pathlib import Path
+
+env = gym.make(
+    "gym_dora/DoraAloha-v0", disable_env_checker=True, max_episode_steps=5000
+)
+observation = env.reset()
+
+
+class ReplayPolicy:
+    def __init__(self, example_path, epidode=1):
+        df_action = pd.read_parquet(example_path / "action.parquet")
+        df_episode_index = pd.read_parquet(example_path / "episode_index.parquet")
+        self.df = pd.merge_asof(
+            df_action[["timestamp_utc", "action"]],
+            df_episode_index[["timestamp_utc", "episode_index"]],
+            on="timestamp_utc",
+            direction="backward",
+        )
+        # self.df["episode_index"] = self.df["episode_index"].map(lambda x: x[0])
+        self.df = self.df[self.df["episode_index"] == epidode]
+        self.current_time = self.df["timestamp_utc"].iloc[0]
+        self.topic = "action"
+        self.index = 0
+        self.finished = False
+
+    def select_action(self, obs):
+        if self.index < len(self.df):
+            self.index += 1
+        else:
+            self.finished = True
+        row = self.df.iloc[self.index]
+        delta_time = (row["timestamp_utc"] - self.current_time).microseconds
+        self.current_time = row["timestamp_utc"]
+        if delta_time > 0:
+            time.sleep(delta_time / 1_000_000)
+        return row[self.topic], self.finished
+
+
+policy = ReplayPolicy(
+    Path(
+        "/home/rcadene/dora-aloha/aloha/graphs/out/018f9b3d-d821-7ea5-9cf0-f6ea8aa7f8f9"
+    )
+)
+done = False
+while not done:
+    actions, finished = policy.select_action(observation)
+
+    observation, reward, terminated, truncated, info = env.step(actions)
+    if terminated:
+        print(observation, reward, terminated, truncated, info, flush=True)
+    done = terminated | truncated | done | finished
+
+env.close()

--- a/aloha/nodes/gym_dora_node.py
+++ b/aloha/nodes/gym_dora_node.py
@@ -6,13 +6,13 @@ import time
 from pathlib import Path
 
 env = gym.make(
-    "gym_dora/DoraAloha-v0", disable_env_checker=True, max_episode_steps=5000
+    "gym_dora/DoraAloha-v0", disable_env_checker=True, max_episode_steps=10000
 )
 observation = env.reset()
 
 
 class ReplayPolicy:
-    def __init__(self, example_path, epidode=1):
+    def __init__(self, example_path, epidode=0):
         df_action = pd.read_parquet(example_path / "action.parquet")
         df_episode_index = pd.read_parquet(example_path / "episode_index.parquet")
         self.df = pd.merge_asof(
@@ -41,11 +41,19 @@ class ReplayPolicy:
         return row[self.topic], self.finished
 
 
+# policy = ReplayPolicy(
+    # Path(
+        # "/home/rcadene/dora-aloha/aloha/graphs/out/018fa076-ad19-7c77-afa4-49f7f072e86f"
+    # )
+# )
+
 policy = ReplayPolicy(
     Path(
-        "/home/rcadene/dora-aloha/aloha/graphs/out/018f9b3d-d821-7ea5-9cf0-f6ea8aa7f8f9"
+        "/home/rcadene/dora-aloha/aloha/graphs/out/018fa4ad-5942-7235-93d3-3efebe9b8a12"
     )
 )
+
+
 done = False
 while not done:
     actions, finished = policy.select_action(observation)

--- a/aloha/nodes/keyboard_node.py
+++ b/aloha/nodes/keyboard_node.py
@@ -5,25 +5,27 @@ from dora import Node
 
 
 node = Node()
-print(node.dataflow_descriptor().keys(), flush=True)
 buffer_text = ""
 space = False
 submitted_text = []
-cursor = 1
+cursor = -1
 with keyboard.Events() as events:
     while True:
         event = events.get(0.1)
         if event is not None and isinstance(event, Events.Press):
             if event.key == Key.space and space == False:
+                cursor += 1
                 node.send_output("space", pa.array([cursor]))
                 space = True
+            
 
         elif event is not None and isinstance(event, Events.Release):
             if event.key == Key.space:
-                node.send_output("space", pa.array([0]))
-                cursor += 1
+                node.send_output("space", pa.array([-1]))
                 space = False
+            elif event.key == Key.backspace:
+                node.send_output("failed", pa.array([cursor]))
+                
 
         if node.next(0.001) is None:
             break
-# 1

--- a/aloha/nodes/lerobot_webcam_saver.py
+++ b/aloha/nodes/lerobot_webcam_saver.py
@@ -18,11 +18,11 @@ CAMERA_HEIGHT = 480
 FPS = 30
 
 i = 0
-episode = 0
+episode = -1
 dataflow_id = node.dataflow_id()
 
 BASE = Path("out") / dataflow_id / "videos"
-out_dir = BASE / f"cam_{CAMERA_NAME}_episode_{episode}"
+out_dir = BASE / f"{CAMERA_NAME}_episode_{episode:06d}"
 
 for event in node:
     event_type = event["type"]
@@ -31,9 +31,9 @@ for event in node:
             record_episode = event["value"].to_numpy()[0]
             print(f"Recording episode {record_episode}", flush=True)
             # Save Episode Video
-            if episode != 0 and record_episode == 0:
-                out_dir = BASE / f"{CAMERA_NAME}_episode_{episode}"
-                fname = f"{CAMERA_NAME}_episode_{episode}.mp4"
+            if episode != -1 and record_episode == -1:
+                out_dir = BASE / f"{CAMERA_NAME}_episode_{episode:06d}"
+                fname = f"{CAMERA_NAME}_episode_{episode:06d}.mp4"
                 video_path = BASE / fname
                 # Save video
                 ffmpeg_cmd = (
@@ -52,9 +52,9 @@ for event in node:
                 episode = record_episode
 
             # Make new directory and start saving images
-            elif episode == 0 and record_episode != 0:
+            elif episode == -1 and record_episode != -1:
                 episode = record_episode
-                out_dir = BASE / f"{CAMERA_NAME}_episode_{episode}"
+                out_dir = BASE / f"{CAMERA_NAME}_episode_{episode:06d}"
                 out_dir.mkdir(parents=True, exist_ok=True)
                 i = 0
             else:
@@ -63,10 +63,10 @@ for event in node:
         elif event["id"] == "image":
             # Only record image when in episode.
             # Episode 0 is for not recording periods.
-            if episode == 0:
+            if episode == -1:
                 continue
 
-            fname = f"{CAMERA_NAME}_episode_{episode}.mp4"
+            fname = f"{CAMERA_NAME}_episode_{episode:06d}.mp4"
             node.send_output(
                 "saved_image",
                 pa.array([{"path": f"videos/{fname}", "timestamp": i / FPS}]),


### PR DESCRIPTION
This PR makes the teleoperated data usable within lerobot as well as evaluate it.

## Getting started

Given you have already setup the aloha arms:

```bash

dora up

# Go to aloha folder
cd aloha

dora start graphs/record_2arms_teleop.yml --attach                                                                                             

# Press Spacebar to record a new episode

# Release Spacebar to stop recording an episode

# Press and release spacebar as many time as episode required.

# Stop the dataflow with ctrl-c

# Copy the data into `data/<DATASET_ID>_raw` folder
cp graphs/out/018f3f3f-9b49-7438-9821-bf7c98f7c0bb data/<DATASET_ID>_raw -r

# then push the dataset to the hub using lerobot script at: https://github.com/huggingface/lerobot/pull/201

# git clone https://github.com/huggingface/lerobot/pull/201 --branch user/rcadene/2024_05_20_dora_parquet_format

python  <Path/to/leorobot>/lerobot/scripts/push_dataset_to_hub.py \
--data-dir data \
--dataset-id <DATASET_ID> \
--raw-format aloha_dora \
--community-id <YOUR_HF_ID>
```

---

This is still work in progress and will update this as we change the script
